### PR TITLE
bumping version # again

### DIFF
--- a/style.css
+++ b/style.css
@@ -5,7 +5,7 @@
  Description:  350 Baseline parent theme
  Author:       Matthew Hinders-Anderson + suzi grishpul
  Author URI:   https://350.org
- Version:      1.6.0.1
+ Version:      1.6.1
  Text Domain:  baseline
  GitHub Theme URI: https://github.com/350org/baseline
 */

--- a/style.scss
+++ b/style.scss
@@ -5,7 +5,7 @@
  Description:  350 Baseline parent theme
  Author:       Matthew Hinders-Anderson + suzi grishpul
  Author URI:   https://350.org
- Version:      1.6.0.1
+ Version:      1.6.1
  Text Domain:  baseline
  GitHub Theme URI: https://github.com/350org/baseline
 */


### PR DESCRIPTION
maybe github updater plugin only checks the first three decimals of the version number?